### PR TITLE
Fix SEP filtering and template loading

### DIFF
--- a/sep_version/sep_version.py
+++ b/sep_version/sep_version.py
@@ -28,15 +28,15 @@ class SEPVersion(IPlugin):
         # The data is data is pulled from the database and passed to a template.
 
         # There are three possible views we're going to be rendering to -
-        # front, bu_dashbaord and group_dashboard. If page is set to
+        # front, bu_dashboard and group_dashboard. If page is set to
         # bu_dashboard, or group_dashboard, you will be passed a business_unit
         # or machine_group id to use (mainly for linking to the right search).
         if page == "front":
             t = loader.get_template(
-                "sheagcraig/sep_version/templates/front.html")
+                "sheagcraig_sal_plugins/sep_version/templates/front.html")
         elif page in ("bu_dashboard", "group_dashboard"):
             t = loader.get_template(
-                "sheagcraig/sep_version/templates/id.html")
+                "sheagcraig_sal_plugins/sep_version/templates/id.html")
 
         data = InventoryItem.objects.filter(
             machine__in=machines,
@@ -53,7 +53,7 @@ class SEPVersion(IPlugin):
 
     def filter_machines(self, machines, data):
         machines = machines.filter(
-            inventoryitem__name="Symantec Endpoint Protection",
+            inventoryitem__application__name="Symantec Endpoint Protection",
             inventoryitem__version=data)
 
         return machines, "Machines with version {} of Symantec Endpoint Protection".format(data)


### PR DESCRIPTION
Includes fixes for both machine filtering and template URLs. I only fixed sep_version’s template URLs, so the other plugins will also need to be updated to reflect the repo’s directory name. It might make sense not to include the repo folder in the template paths at all in case users want to pick and choose which plugins to install.