### PR TITLE
fix: Support 10.13.4 DEP in mdm enrollment

### DIFF
--- a/mdm_enrollment/scripts/mdm_enrollment.py
+++ b/mdm_enrollment/scripts/mdm_enrollment.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-
 import subprocess
 import sys
 import tempfile
@@ -12,6 +11,7 @@ import utils
 
 def main():
     dep_assigned = False
+    dep_enrolled = ''
     mdm_enrolled = False
     user_approved = False
 
@@ -37,14 +37,19 @@ def main():
     else:
         cmd = ['profiles', 'status', '-type', 'enrollment']
         output = subprocess.check_output(cmd)
-        if "An enrollment profile is currently installed on this system" in output:
+        if ("An enrollment profile is currently installed on this system" or
+                "MDM enrollment: Yes") in output:
             mdm_enrolled = True
+        if "Enrolled via DEP: Yes" in output:
+            dep_enrolled = True
+        elif "Enrolled via DEP: No" in output:
+            dep_enrolled = False
 
         user_approved = True if "User Approved" in output else False
 
-    result = 'DEP Assigned: {}, MDM Enrolled: {}, User Approved: {}'.format(
-        dep_assigned, mdm_enrolled, user_approved)
-
+    result = ('DEP Assigned: {}, DEP Enrolled: {}, MDM Enrolled: {}, '
+              'User Approved: {}'.format(
+               dep_assigned, dep_enrolled, mdm_enrolled, user_approved))
 
     utils.add_plugin_results('status', result)
 


### PR DESCRIPTION
* Adds proper support for 10.13.4 for MDM detection

* Properly detect DEP status on 10.13.4 machines. If we're unable to determine the correct state we set sal an empty string `''`

Fix: #5 
