### PR TITLE
Change conditions to facts and restrict to Mac

### DIFF
--- a/battery/battery.py
+++ b/battery/battery.py
@@ -1,16 +1,18 @@
 import sal.plugin
-from server.models import PluginScriptRow
+from server.models import (PluginScriptRow, Fact)
 
 
 class Battery(sal.plugin.DetailPlugin):
 
     description = "Battery Information"
 
+    supported_os_families = [sal.plugin.OSFamilies.darwin]
+
     def get_context(self, machine, **kwargs):
         context = self.super_get_context(machine, **kwargs)
         try:
-            machine_type = machine.conditions.filter(
-                condition_name="machine_type").first().condition_data
+            machine_type = machine.facts.filter(
+                fact_name="machine_type").first().fact_data
         except AttributeError:
             # If there are no results, None has no `condition_data` attr
             machine_type = None

--- a/battery/battery.py
+++ b/battery/battery.py
@@ -1,11 +1,10 @@
 import sal.plugin
-from server.models import (PluginScriptRow, Fact)
+from server.models import PluginScriptRow
 
 
 class Battery(sal.plugin.DetailPlugin):
 
     description = "Battery Information"
-
     supported_os_families = [sal.plugin.OSFamilies.darwin]
 
     def get_context(self, machine, **kwargs):


### PR DESCRIPTION
Server would only display "unknown" for this plugin so I changed the module from conditions to facts and it now works.  I also restricted it to Macs since I don't think Chrome can report battery stats and I don't see much about Windows or Linux client facts.