### PR TITLE
utils import wasnt working 

### DIFF
--- a/salt_machine_detail/scripts/salt_machine_detail.py
+++ b/salt_machine_detail/scripts/salt_machine_detail.py
@@ -1,12 +1,9 @@
-#!/usr/bin/python
-
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 import json
 import os
-import sys
 
-sys.path.append("/usr/local/sal")
-import utils
+import sal 
 
 
 salt_highstate_log = '/var/log/salt/events'
@@ -24,7 +21,7 @@ def main():
     except:
         result = {}
 
-    utils.add_plugin_results('SaltMachineDetail', result)
+    sal.utils.add_plugin_results('SaltMachineDetail', result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I think pointing the shebang to use the sal scripts version _should_ be fine but understand if you want to use the system python.