### PR TITLE
Fix Python3 shebang, fix MDM scripts, Black formatting

### DIFF
--- a/battery/scripts/battery_script.py
+++ b/battery/scripts/battery_script.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 """Shamelessly taken from https://github.com/chilcote/unearth
 with minor changes to use "plistlib.loads" by Nathan Darnell"""
 
@@ -11,7 +11,7 @@ import sal
 
 def main():
     data = battery_facts()
-    sal.add_plugin_results('Battery', data)
+    sal.add_plugin_results("Battery", data)
 
 
 def battery_facts():
@@ -28,11 +28,13 @@ def battery_facts():
         stdout, _ = proc.communicate()
         if stdout:
             d = plistlib.loads(stdout)[0]
-            result['BatteryHealth'] = "Healthy" if not d["PermanentFailureStatus"] else "Failing"
-            result['MaxCapacity'] = d["MaxCapacity"]
-            result['DesignCapacity'] = d["DesignCapacity"]
-            result['CycleCount'] = d["CycleCount"]
-            result['DesignCycleCount9C'] = d["DesignCycleCount9C"]
+            result["BatteryHealth"] = (
+                "Healthy" if not d["PermanentFailureStatus"] else "Failing"
+            )
+            result["MaxCapacity"] = d["MaxCapacity"]
+            result["DesignCapacity"] = d["DesignCapacity"]
+            result["CycleCount"] = d["CycleCount"]
+            result["DesignCycleCount9C"] = d["DesignCycleCount9C"]
     except (IOError, OSError):
         pass
 

--- a/dep_assignment/scripts/dep_assignment.py
+++ b/dep_assignment/scripts/dep_assignment.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import subprocess
@@ -10,17 +10,17 @@ import sal
 def main():
     dep_assigned = False
 
-    cmd = ['/usr/bin/profiles', '-e']
+    cmd = ["/usr/bin/profiles", "-e"]
     try:
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
     except subprocess.CalledProcessError as error:
         output = str(error.output)
-    if len(output[output.find('{') + 1: output.find('}')].strip()) > 0:
+    if len(output[output.find("{") + 1 : output.find("}")].strip()) > 0:
         dep_assigned = True
 
-    result = {'dep_status': '{}Assigned'.format('' if dep_assigned else 'Not ')}
+    result = {"dep_status": "{}Assigned".format("" if dep_assigned else "Not ")}
 
-    sal.add_plugin_results('dep_assignment', result)
+    sal.add_plugin_results("dep_assignment", result)
 
 
 if __name__ == "__main__":

--- a/machine_detail_mdm_enrollment/scripts/machine_detail_mdm_enrollment.py
+++ b/machine_detail_mdm_enrollment/scripts/machine_detail_mdm_enrollment.py
@@ -61,7 +61,7 @@ def profiles_status():
 
     parsed = {}
     for line in result.splitlines():
-        key, val = line.split(":")
+        key, val = line.split(": ")
         parsed[key.strip()] = val.strip()
 
     return parsed

--- a/mdm_enrollment/scripts/mdm_enrollment.py
+++ b/mdm_enrollment/scripts/mdm_enrollment.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import plistlib
@@ -10,8 +10,8 @@ from distutils.version import LooseVersion
 import sal
 
 
-MANUAL_PROFILE_DISPLAY_NAME = 'Root MDM Profile'
-DEP_PROFILE_DISPLAY_NAME = 'MobileIron Cloud DEP MDM Profile'
+MANUAL_PROFILE_DISPLAY_NAME = "Root MDM Profile"
+DEP_PROFILE_DISPLAY_NAME = "MobileIron Cloud DEP MDM Profile"
 
 
 def main():
@@ -19,35 +19,39 @@ def main():
 
     # 10.13.4 is when the profiles command gained the ability to
     # report on UAMDM status.
-    if os_version() < LooseVersion('10.13.4'):
-        result['mdm_status'] = get_enrollment_from_mdm_profile()
+    if os_version() < LooseVersion("10.13.4"):
+        result["mdm_status"] = get_enrollment_from_mdm_profile()
 
     else:
         status = profiles_status()
-        if status.get('Enrolled via DEP') == 'Yes':
-            result['mdm_status'] = 'DEP'
+        if status.get("Enrolled via DEP") == "Yes":
+            result["mdm_status"] = "DEP"
         else:
-            result['mdm_status'] = 'Manually Enrolled' if 'Yes' in status.get('MDM enrollment', '') else 'No'
+            result["mdm_status"] = (
+                "Manually Enrolled"
+                if "Yes" in status.get("MDM enrollment", "")
+                else "No"
+            )
 
-    sal.add_plugin_results('mdm_enrollment', result)
+    sal.add_plugin_results("mdm_enrollment", result)
 
 
 def os_version():
-    cmd = ['/usr/bin/sw_vers', '-productVersion']
+    cmd = ["/usr/bin/sw_vers", "-productVersion"]
     output = subprocess.check_output(cmd, text=True)
     return LooseVersion(output)
 
 
 def profiles_status():
-    cmd = ['/usr/bin/profiles', 'status', '-type', 'enrollment']
+    cmd = ["/usr/bin/profiles", "status", "-type", "enrollment"]
     try:
         result = subprocess.check_output(cmd, text=True)
     except subprocess.CalledProcessError:
-        result = ''
+        result = ""
 
     parsed = {}
     for line in result.splitlines():
-        key, val = line.split(':')
+        key, val = line.split(":")
         parsed[key.strip()] = val.strip()
 
     return parsed
@@ -55,33 +59,33 @@ def profiles_status():
 
 def get_enrollment_from_mdm_profile():
     mdm_enrolled = False
-    cmd = ['/usr/bin/profiles', '-C', '-o', 'stdout-xml']
+    cmd = ["/usr/bin/profiles", "-C", "-o", "stdout-xml"]
     plist_text = subprocess.check_output(cmd, text=True)
     plist = plistlib.readPlistFromString(plist_text)
 
-    for profile in plist.get('_computerlevel', []):
-        for item in profile['ProfileItems']:
-            if item['PayloadType'] == 'com.apple.mdm':
+    for profile in plist.get("_computerlevel", []):
+        for item in profile["ProfileItems"]:
+            if item["PayloadType"] == "com.apple.mdm":
                 mdm_enrolled = True
                 # You should change this to your MDM provider's Manual enrollment name!
-                if profile['ProfileDisplayName'] == MANUAL_PROFILE_DISPLAY_NAME:
+                if profile["ProfileDisplayName"] == MANUAL_PROFILE_DISPLAY_NAME:
                     dep = False
-                elif profile['ProfileDisplayName'] == DEP_PROFILE_DISPLAY_NAME:
+                elif profile["ProfileDisplayName"] == DEP_PROFILE_DISPLAY_NAME:
                     dep = True
                 else:
-                    dep = 'Unknown'
+                    dep = "Unknown"
                 break
             if mdm_enrolled:
                 break
 
     if mdm_enrolled and dep is True:
-        status = 'DEP'
+        status = "DEP"
     elif mdm_enrolled and dep is False:
-        status = 'Manually Enrolled'
-    elif mdm_enrolled and dep == 'Unknown':
-        status = 'Enrolled with unknown server'
+        status = "Manually Enrolled"
+    elif mdm_enrolled and dep == "Unknown":
+        status = "Enrolled with unknown server"
     else:
-        status = 'No'
+        status = "No"
 
     return status
 

--- a/mdm_enrollment/scripts/mdm_enrollment.py
+++ b/mdm_enrollment/scripts/mdm_enrollment.py
@@ -51,7 +51,7 @@ def profiles_status():
 
     parsed = {}
     for line in result.splitlines():
-        key, val = line.split(":")
+        key, val = line.split(": ")
         parsed[key.strip()] = val.strip()
 
     return parsed


### PR DESCRIPTION
I had previously pinned these to version `#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3` and that broke when Sal's python changed to 3.9.  Now changed to `#!/usr/local/sal/Python.framework/Versions/Current/bin/python3` in these four scripts.

Both MDM scripts were splitting the output of `/usr/bin/profiles status -type enrollment` into key-value pairs by the colon.  The MDM server returned: `MDM server: https://...` and was returning three values.  Adding a space after the colon seems to have fixed that.

I have Black turned on so it added its two cents on the formatting.  Let me know if that doesn't work for you and I'll take that out.